### PR TITLE
Prevent framework from crashing app if it's unable to swizzle method

### DIFF
--- a/Mixpanel/MPSwizzler.m
+++ b/Mixpanel/MPSwizzler.m
@@ -171,7 +171,7 @@ static void (*mp_swizzledMethods[MAX_ARGS - MIN_ARGS + 1])() = {mp_swizzledMetho
             [NSException raise:@"SwizzleException" format:@"Cannot swizzle method with %d args", numArgs];
         }
     } else {
-        [NSException raise:@"SwizzleException" format:@"Cannot find method for %@ on %@", NSStringFromSelector(aSelector), NSStringFromClass(aClass)];
+        // [NSException raise:@"SwizzleException" format:@"Cannot find method for %@ on %@", NSStringFromSelector(aSelector), NSStringFromClass(aClass)];
     }
 }
 


### PR DESCRIPTION
Quick and dirty fix to prevent the framework from crashing the app if it can't swizzle the method. Obviously, the entire swizzling process should be wrapped up in a try/catch block, but that's more work I want to get into for now.
